### PR TITLE
Use fixed slate-irc for slack gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "read": "^1.0.5",
     "request": "^2.51.0",
     "rx": "^2.5.2",
-    "slate-irc": "~0.8.1",
+    "slate-irc": "karen-irc/slate-irc.git#b12d540fa231b64e4e012c9e29412a2dc448acbe",
     "socket.io": "~1.0.6",
     "socket.io-client": "^1.3.5"
   },


### PR DESCRIPTION
slack gateway's welcome message includes messages in middle line (basically this is included trailing line).