### PR TITLE
Network name changed automatically to host name

### DIFF
--- a/src/models/Network.js
+++ b/src/models/Network.js
@@ -57,7 +57,7 @@ function Network(attr) {
     this.id = data.id;
 
     /** @type   {string}    */
-    this.name = (data.name === '') ? data.name : prettify(data.host);
+    this.name = (data.name !== '') ? data.name : prettify(data.host);
 
     /** @type   {string}    */
     this.host = data.host;


### PR DESCRIPTION
Fix regression from 3bb266cf28b01a78b7f755cd0f04fa566afafab0.