### PR TITLE
Clean up gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,5 +150,6 @@ gulp.task('clean:client', function (callback) {
 });
 
 gulp.task('build:client', ['__handlebars', '__uglify', '__copy']);
+gulp.task('build', ['jslint', 'build:client']);
 gulp.task('clean', ['clean:client']);
-gulp.task('default', ['jslint', 'build:client']);
+gulp.task('default', ['build']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ let babelify = require('babelify');
 let browserify = require('browserify');
 let childProcess = require('child_process');
 let concat = require('gulp-concat');
+let del = require('del');
 let eslint = require('gulp-eslint');
 let gulp = require('gulp');
 let path = require('path');
@@ -50,14 +51,15 @@ const SRC = [
     'client/js/libs/uri.js',
 ];
 
-const DIST_JS = 'client/dist/js/';
+const DIST_CLIENT = './client/dist/';
+const DIST_CLIENT_JS = path.resolve(DIST_CLIENT, './js/');
 
 gulp.task('uglify', function () {
     return gulp.src(SRC)
         .pipe(uglify('libs.min.js', {
             compress: false,
         }))
-        .pipe(gulp.dest(DIST_JS));
+        .pipe(gulp.dest(DIST_CLIENT_JS));
 });
 
 gulp.task('copy', function () {
@@ -65,7 +67,7 @@ gulp.task('copy', function () {
         './node_modules/rx/dist/rx.js',
     ];
     return gulp.src(src)
-        .pipe(gulp.dest(DIST_JS));
+        .pipe(gulp.dest(DIST_CLIENT_JS));
 });
 
 gulp.task('build', ['copy'], function () {
@@ -74,7 +76,7 @@ gulp.task('build', ['copy'], function () {
         String(handlebars),
         'client/views/',
         '-e', 'tpl',
-        '-f', 'client/dist/js/karen.templates.js',
+        '-f', path.resolve(DIST_CLIENT, './js/karen.templates.js'),
     ];
 
     let option = {
@@ -125,6 +127,13 @@ gulp.task('build2', ['jslint'], function () {
         .pipe(gulp.dest('client/dist/'));
 });
 
+gulp.task('clean:client', function (callback) {
+    return del([
+        DIST_CLIENT,
+    ], callback);
+});
+
+gulp.task('clean', ['clean:client']);
 gulp.task('default', ['uglify', 'build']);
 
 gulp.task('watch', ['uglify'], function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,7 +54,7 @@ const SRC = [
 const DIST_CLIENT = './client/dist/';
 const DIST_CLIENT_JS = path.resolve(DIST_CLIENT, './js/');
 
-gulp.task('uglify', function () {
+gulp.task('__uglify', ['clean:client'], function () {
     return gulp.src(SRC)
         .pipe(uglify('libs.min.js', {
             compress: false,
@@ -62,7 +62,7 @@ gulp.task('uglify', function () {
         .pipe(gulp.dest(DIST_CLIENT_JS));
 });
 
-gulp.task('copy', function () {
+gulp.task('__copy', ['clean:client'], function () {
     var src = [
         './node_modules/rx/dist/rx.js',
     ];
@@ -70,7 +70,7 @@ gulp.task('copy', function () {
         .pipe(gulp.dest(DIST_CLIENT_JS));
 });
 
-gulp.task('build', ['copy'], function () {
+gulp.task('__handlebars', ['clean:client'], function () {
     let handlebars = path.relative(__dirname, './node_modules/handlebars/bin/handlebars');
     let args = [
         String(handlebars),
@@ -102,7 +102,7 @@ gulp.task('jslint', function () {
         .pipe(eslint.failAfterError());
 });
 
-gulp.task('build2', ['jslint'], function () {
+gulp.task('build:client2', ['jslint'], function () {
     const SRC_JS = ['./client/script/karen.js'];
 
     let option = {
@@ -133,9 +133,10 @@ gulp.task('clean:client', function (callback) {
     ], callback);
 });
 
+gulp.task('build:client', ['__handlebars', '__uglify', '__copy']);
 gulp.task('clean', ['clean:client']);
-gulp.task('default', ['uglify', 'build']);
+gulp.task('default', ['jslint', 'build:client']);
 
-gulp.task('watch', ['uglify'], function () {
-    gulp.watch(SRC, ['uglify']);
+gulp.task('watch', ['build:client'], function () {
+    gulp.watch(SRC, ['build:client']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,22 @@ const SRC = [
 const DIST_CLIENT = './client/dist/';
 const DIST_CLIENT_JS = path.resolve(DIST_CLIENT, './js/');
 
+/**
+ *  # The rules of task name
+ *
+ *  ## public task
+ *  - This is completed in itself.
+ *  - This is callable as `gulp <taskname>`.
+ *
+ *  ## private task
+ *  - This has some sideeffect in dependent task trees
+ *    and it cannot recovery by self.
+ *  - This is __callable only from public task__.
+ *    DONT CALL as `gulp <taskname>`.
+ *  - MUST name `__taskname`.
+ */
+
+
 gulp.task('__uglify', ['clean:client'], function () {
     return gulp.src(SRC)
         .pipe(uglify('libs.min.js', {
@@ -136,7 +152,3 @@ gulp.task('clean:client', function (callback) {
 gulp.task('build:client', ['__handlebars', '__uglify', '__copy']);
 gulp.task('clean', ['clean:client']);
 gulp.task('default', ['jslint', 'build:client']);
-
-gulp.task('watch', ['build:client'], function () {
-    gulp.watch(SRC, ['build:client']);
-});

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "babelify": "^6.0.2",
     "browserify": "^9.0.8",
+    "del": "^1.1.1",
     "eslint": "^0.20.0",
     "eslint-plugin-react": "^2.2.0",
     "gulp": "^3.8.11",


### PR DESCRIPTION
## Added tasks
- `clean`
  - `clean:client`
- `build` (behavior is changed)
  - `build:client`

## Removed tasks
- `watch`

## Introduce a rules to name tasks

we introduce a naming rule to manage our tasks.

### public task
 - This is completed in itself.
 - This is callable as `gulp <taskname>`.

### private task
 - This has some sideeffect in dependent task trees and it cannot recovery by self.
 - This is __callable only from public task__.  __DONT CALL__ as `gulp <taskname>`.
 - __MUST__ name `__taskname`.
 
