### PR TITLE
Call `gulp default` before running tests on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: node_js
 
 before_script:
+  - node_modules/.bin/gulp default
   - ./index.js init
 
 node_js:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prestart": "gulp default",
-    "start": "node index",
+    "start": "iojs index",
     "test": "npm run lint && npm run unit-test",
     "lint": "gulp jslint",
     "unit-test": "mocha test/**/*.js"


### PR DESCRIPTION
In before_script phase, call `gulp default` to build all files.