### PR TITLE
Introduce ES6 modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,12 +3,11 @@
     // http://eslint.org/docs/configuring/#comments-in-configuration-files
 
     "ecmaFeatures": {
-        // "modules": true // FIXME: #69
+        "blockBindings": true
     },
 
     "env": {
         "node": true,
-        "es6": true,
     },
 
     "plugins": [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 'use strict';
 
 let babel = require('gulp-babel');

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,14 @@
+
+{
+    // ESLint Configuration Files enables to include comments.
+    // http://eslint.org/docs/configuring/#comments-in-configuration-files
+
+    "ecmaFeatures": {
+        "modules": true
+    },
+
+    "env": {
+        "node": true,
+        "es6": true,
+    }
+}

--- a/src/client.js
+++ b/src/client.js
@@ -1,21 +1,17 @@
-'use strict';
-
-var _ = require('lodash');
-var Chan = require('./models/Channel');
-var ChannelType = require('./models/ChannelType');
-var crypto = require('crypto');
-var fs = require('fs');
-var identd = require('./identd');
-var log = require('./log');
-var net = require('net');
-var Msg = require('./models/Message');
-var MessageType = require('./models/MessageType');
-var Network = require('./models/Network');
-var slate = require('slate-irc');
-var tls = require('tls');
-var Helper = require('./helper');
-
-module.exports = Client;
+import _ from 'lodash';
+import Chan from './models/Channel';
+import ChannelType from './models/ChannelType';
+import crypto from 'crypto';
+import fs from 'fs';
+import identd from './identd';
+import log from './log';
+import net from 'net';
+import Msg from './models/Message';
+import MessageType from './models/MessageType';
+import Network from './models/Network';
+import slate from 'slate-irc';
+import tls from 'tls';
+import Helper from './helper';
 
 var id = 0;
 var events = [
@@ -54,7 +50,7 @@ var inputs = [
     'whois'
 ];
 
-function Client(sockets, name, config) {
+export default function Client(sockets, name, config) {
     _.merge(this, {
         activeChannel: -1,
         config: config,

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -1,18 +1,14 @@
-'use strict';
-
-var _ = require('lodash');
-var fs = require('fs');
-var Client = require('./client');
-var mkdirp = require('mkdirp');
-var Helper = require('./helper');
-var moment = require('moment');
-
-module.exports = ClientManager;
+import _ from 'lodash';
+import fs from 'fs';
+import Client from './client';
+import mkdirp from 'mkdirp';
+import Helper from './helper';
+import moment from 'moment';
 
 /**
  *  @constructor
  */
-function ClientManager() {
+export default function ClientManager() {
     this.clients = [];
 }
 

--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -1,11 +1,22 @@
-'use strict';
+import ClientManager from '../clientManager';
+import bcrypt from 'bcrypt-nodejs';
+import fs from 'fs';
+import program from 'commander';
+import mkdirp from 'mkdirp';
+import Helper from '../helper';
 
-var ClientManager = require('../clientManager');
-var bcrypt = require('bcrypt-nodejs');
-var fs = require('fs');
-var program = require('commander');
-var mkdirp = require('mkdirp');
-var Helper = require('../helper');
+function add(manager, name, password) {
+    console.log('');
+    var salt = bcrypt.genSaltSync(8);
+    var hash = bcrypt.hashSync(password, salt);
+    manager.addUser(
+        name,
+        hash
+    );
+    console.log('User \'' + name + '\' created:');
+    console.log(Helper.HOME + '/users/' + name + '.json');
+    console.log('');
+}
 
 program
     .command('add <name>')
@@ -49,16 +60,3 @@ program
             }
         });
     });
-
-function add(manager, name, password) {
-    console.log('');
-    var salt = bcrypt.genSaltSync(8);
-    var hash = bcrypt.hashSync(password, salt);
-    manager.addUser(
-        name,
-        hash
-    );
-    console.log('User \'' + name + '\' created:');
-    console.log(Helper.HOME + '/users/' + name + '.json');
-    console.log('');
-}

--- a/src/command-line/config.js
+++ b/src/command-line/config.js
@@ -1,11 +1,9 @@
-'use strict';
-
-var fs = require('fs');
-var path = require('path');
-var program = require('commander');
-var mkdirp = require('mkdirp');
-var child = require('child_process');
-var Helper = require('../helper');
+import fs from 'fs';
+import path from 'path';
+import program from 'commander';
+import mkdirp from 'mkdirp';
+import child from 'child_process';
+import Helper from '../helper';
 
 program
     .command('config')

--- a/src/command-line/edit.js
+++ b/src/command-line/edit.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var ClientManager = require('../clientManager');
-var program = require('commander');
-var child = require('child_process');
-var Helper = require('../helper');
+import ClientManager from '../clientManager';
+import program from 'commander';
+import child from 'child_process';
+import Helper from '../helper';
 
 program
     .command('edit <name>')

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -1,23 +1,21 @@
-'use strict';
-
-var path = require('path');
-var program = require('commander');
-var pkg = require('../../package.json');
-var fs = require('fs');
-var mkdirp = require('mkdirp');
-var Helper = require('../helper');
+import path from 'path';
+import program from 'commander';
+import pkg from '../../package.json';
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+import Helper from '../helper';
 
 program.version(pkg.version, '-v, --version');
 program.option('');
 program.option('    --home <path>', 'home path');
 
-require('./start');
-require('./config');
-require('./list');
-require('./add');
-require('./remove');
-require('./reset');
-require('./edit');
+import './start';
+import './config';
+import './list';
+import './add';
+import './remove';
+import './reset';
+import './edit';
 
 var argv = program.parseOptions(process.argv);
 if (program.home) {

--- a/src/command-line/list.js
+++ b/src/command-line/list.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var ClientManager = require('../clientManager');
-var program = require('commander');
+import ClientManager from '../clientManager';
+import program from 'commander';
 
 program
     .command('list')

--- a/src/command-line/remove.js
+++ b/src/command-line/remove.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var ClientManager = require('../clientManager');
-var fs = require('fs');
-var program = require('commander');
-var Helper = require('../helper');
+import ClientManager from '../clientManager';
+import fs from 'fs';
+import program from 'commander';
+import Helper from '../helper';
 
 program
     .command('remove <name>')

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var bcrypt = require('bcrypt-nodejs');
-var ClientManager = require('../clientManager');
-var fs = require('fs');
-var program = require('commander');
-var Helper = require('../helper');
+import bcrypt from 'bcrypt-nodejs';
+import ClientManager from '../clientManager';
+import fs from 'fs';
+import program from 'commander';
+import Helper from '../helper';
 
 program
     .command('reset <name>')

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var _ = require('lodash');
-var ClientManager = require('../clientManager');
-var program = require('commander');
-var karen = require('../server');
-var Helper = require('../helper');
+import _ from 'lodash';
+import ClientManager from '../clientManager';
+import program from 'commander';
+import karen from '../server';
+import Helper from '../helper';
 
 program
     .option('-H, --host <ip>', 'host')

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,12 +1,12 @@
-'use strict';
+import path from 'path';
 
-var path = require('path');
-
-module.exports = {
-    HOME: (process.env.HOME || process.env.USERPROFILE) + '/.karen',
-    getConfig: getConfig,
-};
+const HOME = (process.env.HOME || process.env.USERPROFILE) + '/.karen';
 
 function getConfig() {
     return require(path.resolve(this.HOME) + '/config');
 }
+
+export default {
+    HOME,
+    getConfig
+};

--- a/src/log.js
+++ b/src/log.js
@@ -1,11 +1,9 @@
-'use strict';
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+import moment from 'moment';
+import Helper from './helper';
 
-var fs = require('fs');
-var mkdirp = require('mkdirp');
-var moment = require('moment');
-var Helper = require('./helper');
-
-module.exports.write = function(user, network, chan, msg) {
+function write(user, network, chan, msg) {
     var path = Helper.HOME + '/logs/' + user + '/' + network;
     try {
         mkdirp.sync(path);
@@ -44,4 +42,8 @@ module.exports.write = function(user, network, chan, msg) {
             }
         }
     );
+}
+
+export default {
+    write
 };

--- a/src/models/Channel.js
+++ b/src/models/Channel.js
@@ -22,11 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
-
-const _ = require('lodash');
-const assign = require('object-assign');
-const ChannelType = require('./ChannelType');
+import _ from 'lodash';
+import assign from 'object-assign';
+import ChannelType from './ChannelType';
 
 const MODES = [
     '~',
@@ -38,7 +36,7 @@ const MODES = [
 
 let id = 0;
 
-function Channal(attr) {
+export default function Channal(attr) {
     let data = assign({
         id: id++,
         messages: [],
@@ -110,5 +108,3 @@ Channal.prototype = {
         return clone;
     },
 };
-
-module.exports = Channal;

--- a/src/models/ChannelType.js
+++ b/src/models/ChannelType.js
@@ -22,13 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
 /** @enum {string} */
-const ChannelType = Object.freeze({
+export default Object.freeze({
     CHANNEL: 'channel',
     LOBBY: 'lobby',
     QUERY: 'query',
 });
-
-module.exports = ChannelType;

--- a/src/models/Hostmask.js
+++ b/src/models/Hostmask.js
@@ -22,11 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
-function Hostmask(attr) {
+export default function Hostmask(attr) {
     let data = assign({
         nick: '',
         username: '',
@@ -46,5 +45,3 @@ function Hostmask(attr) {
     /** @type   {number}    */
     this.string = data.string;
 }
-
-module.exports = Hostmask;

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -22,15 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
-const assign = require('object-assign');
-const moment = require('moment');
-const MessageType = require('./MessageType');
+import assign from 'object-assign';
+import moment from 'moment';
+import MessageType from './MessageType';
 
 let id = 0;
 
-function Message(attr) {
+export default function Message(attr) {
     let data = assign({
         type: MessageType.MESSAGE,
         id: id++,
@@ -62,5 +61,3 @@ function Message(attr) {
     /** @type   {boolean}   */
     this.self = data.self;
 }
-
-module.exports = Message;

--- a/src/models/MessageType.js
+++ b/src/models/MessageType.js
@@ -22,10 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
 /** @enum {string} */
-const MessageType = Object.freeze({
+export default Object.freeze({
     ACTION: 'action',
     ERROR: 'error',
     JOIN: 'join',
@@ -41,5 +40,3 @@ const MessageType = Object.freeze({
     TOPIC: 'topic',
     WHOIS: 'whois'
 });
-
-module.exports = MessageType;

--- a/src/models/Network.js
+++ b/src/models/Network.js
@@ -22,21 +22,45 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
-const _ = require('lodash');
-const assign = require('object-assign');
-const Channel = require('./Channel');
-const ChannelType = require('./ChannelType');
+import _ from 'lodash';
+import assign from 'object-assign';
+import Channel from './Channel';
+import ChannelType from './ChannelType';
 
 /** @type   {number}    */
 let id = 0;
 
 /**
+ *  @param  {string}    str
+ *  @return {string}
+ *  @throws {Error}
+ */
+function capitalize(str) {
+    if (typeof str !== 'string') {
+        throw new Error();
+    }
+
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ *  @param  {string}    host
+ *  @return {string}
+ */
+function prettify(host) {
+    let name = capitalize(host.split('.')[1]);
+    if (!name) {
+        name = host;
+    }
+    return name;
+}
+
+/**
  *  @constructor
  *  @param  {Object} attr
  */
-function Network(attr) {
+export default function Network(attr) {
     let data = assign({
         name: '',
         host: '',
@@ -129,30 +153,3 @@ Network.prototype = {
         return _.omit(json, 'irc', 'password');
     },
 };
-
-/**
- *  @param  {string}    host
- *  @return {string}
- */
-function prettify(host) {
-    let name = capitalize(host.split('.')[1]);
-    if (!name) {
-        name = host;
-    }
-    return name;
-}
-
-/**
- *  @param  {string}    str
- *  @return {string}
- *  @throws {Error}
- */
-function capitalize(str) {
-    if (typeof str !== 'string') {
-        throw new Error();
-    }
-
-    return str.charAt(0).toUpperCase() + str.slice(1);
-}
-
-module.exports = Network;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -22,11 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-'use strict';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
-function User(attr) {
+export default function User(attr) {
     let data = assign({
         mode: '',
         name: '',
@@ -38,5 +37,3 @@ function User(attr) {
     /** @type {string} */
     this.name = data.name;
 }
-
-module.exports = User;

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -1,9 +1,7 @@
-'use strict';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'slap' && cmd !== 'me') {
         return;
     }
@@ -41,4 +39,4 @@ module.exports = function(network, chan, cmd, args) {
             });
             break;
     }
-};
+}

--- a/src/plugins/inputs/connect.js
+++ b/src/plugins/inputs/connect.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'connect' && cmd !== 'server') {
         return;
     }
@@ -10,4 +8,4 @@ module.exports = function(network, chan, cmd, args) {
             host: args[0]
         });
     }
-};
+}

--- a/src/plugins/inputs/invite.js
+++ b/src/plugins/inputs/invite.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'invite') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
     if (args.length === 2) {
         irc.invite(args[0], args[1]);
     }
-};
+}

--- a/src/plugins/inputs/join.js
+++ b/src/plugins/inputs/join.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'join') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
         var irc = network.irc;
         irc.join(args[0], args[1]);
     }
-};
+}

--- a/src/plugins/inputs/kick.js
+++ b/src/plugins/inputs/kick.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'kick') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
         var irc = network.irc;
         irc.kick(chan.name, args[0]);
     }
-};
+}

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'mode' && cmd !== 'op' && cmd !== 'voice' && cmd !== 'deop' && cmd !== 'devoice') {
         return;
     } else if (args.length === 0) {
@@ -29,4 +27,4 @@ module.exports = function(network, chan, cmd, args) {
         mode,
         user
     );
-};
+}

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -1,8 +1,6 @@
-'use strict';
+import _ from 'lodash';
 
-var _ = require('lodash');
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'say' && cmd !== 'msg') {
         return;
     }
@@ -30,4 +28,4 @@ module.exports = function(network, chan, cmd, args) {
             message: msg
         });
     }
-};
+}

--- a/src/plugins/inputs/nick.js
+++ b/src/plugins/inputs/nick.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'nick') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
         var irc = network.irc;
         irc.nick(args[0]);
     }
-};
+}

--- a/src/plugins/inputs/notice.js
+++ b/src/plugins/inputs/notice.js
@@ -1,9 +1,7 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'notice' || !args[1]) {
         return;
     }
     var irc = network.irc;
     irc.notice(args[0], args.slice(1).join(' '));
-};
+}

--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -1,8 +1,6 @@
-'use strict';
+import _ from 'lodash';
 
-var _ = require('lodash');
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'part' && cmd !== 'leave' && cmd !== 'close') {
         return;
     }
@@ -19,4 +17,4 @@ module.exports = function(network, chan, cmd, args) {
         }
         irc.part(args);
     }
-};
+}

--- a/src/plugins/inputs/quit.js
+++ b/src/plugins/inputs/quit.js
@@ -1,8 +1,6 @@
-'use strict';
+import _ from 'lodash';
 
-var _ = require('lodash');
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'quit' && cmd !== 'disconnect') {
         return;
     }
@@ -18,4 +16,4 @@ module.exports = function(network, chan, cmd, args) {
     });
 
     irc.quit(quitMessage);
-};
+}

--- a/src/plugins/inputs/raw.js
+++ b/src/plugins/inputs/raw.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'raw' && cmd !== 'send' && cmd !== 'quote') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
         var irc = network.irc;
         irc.write(args.join(' '));
     }
-};
+}

--- a/src/plugins/inputs/services.js
+++ b/src/plugins/inputs/services.js
@@ -1,8 +1,6 @@
-'use strict';
+import _ from 'lodash';
 
-var _ = require('lodash');
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'ns' && cmd !== 'cs' && cmd !== 'hs') {
         return;
     }
@@ -25,4 +23,4 @@ module.exports = function(network, chan, cmd, args) {
             message: msg
         });
     }
-};
+}

--- a/src/plugins/inputs/topic.js
+++ b/src/plugins/inputs/topic.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'topic') {
         return;
     }
@@ -11,4 +9,4 @@ module.exports = function(network, chan, cmd, args) {
 
     var irc = network.irc;
     irc.write(msg);
-};
+}

--- a/src/plugins/inputs/whois.js
+++ b/src/plugins/inputs/whois.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(network, chan, cmd, args) {
+export default function(network, chan, cmd, args) {
     if (cmd !== 'whois' && cmd !== 'query') {
         return;
     }
@@ -8,4 +6,4 @@ module.exports = function(network, chan, cmd, args) {
         var irc = network.irc;
         irc.whois(args[0]);
     }
-};
+}

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -1,8 +1,6 @@
-'use strict';
-
 var pkg = require(process.cwd() + '/package.json');
 
-module.exports = function(irc, network) {
+export default function(irc, network) {
     irc.on('message', function(data) {
         if (data.message.indexOf('\u0001') !== 0) {
             return;
@@ -23,4 +21,4 @@ module.exports = function(irc, network) {
                 break;
         }
     });
-};
+}

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -1,9 +1,7 @@
-'use strict';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('errors', function(data) {
         var lobby = network.channels[0];
@@ -22,4 +20,4 @@ module.exports = function(irc, network) {
             }
         }
     });
-};
+}

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -1,12 +1,10 @@
-'use strict';
+import _ from 'lodash';
+import Chan from '../../models/Channel';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
+import User from '../../models/User';
 
-var _ = require('lodash');
-var Chan = require('../../models/Channel');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-var User = require('../../models/User');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('join', function(data) {
         var chan = _.find(network.channels, {name: data.channel});
@@ -43,4 +41,4 @@ module.exports = function(irc, network) {
             msg: msg
         });
     });
-};
+}

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('kick', function(data) {
         var from = data.nick;
@@ -44,4 +42,4 @@ module.exports = function(irc, network) {
             msg: msg
         });
     });
-};
+}

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -1,100 +1,12 @@
-'use strict';
-
-var _ = require('lodash');
-var cheerio = require('cheerio');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-var request = require('request');
-var Helper = require('../../helper');
-var es = require('event-stream');
+import _ from 'lodash';
+import cheerio from 'cheerio';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
+import request from 'request';
+import Helper from '../../helper';
+import es from 'event-stream';
 
 process.setMaxListeners(0);
-
-module.exports = function(irc, network) {
-    var client = this;
-    irc.on('message', function(data) {
-        var config = Helper.getConfig();
-        if (!config.prefetch) {
-            return;
-        }
-
-        var links = [];
-        var split = data.message.split(' ');
-        _.each(split, function(w) {
-            if (w.match(/^(http|https):\/\/localhost/g)) {
-                return;
-            }
-            var match = w.indexOf('http://') === 0 || w.indexOf('https://') === 0;
-            if (match) {
-                links.push(w);
-            }
-        });
-
-        if (links.length === 0) {
-            return;
-        }
-
-        var self = data.to.toLowerCase() === irc.me.toLowerCase();
-        var chan = _.findWhere(network.channels, {name: self ? data.from : data.to});
-        if (typeof chan === 'undefined') {
-            return;
-        }
-
-        var msg = new Msg({
-            type: MessageType.TOGGLE,
-            time: ''
-        });
-        chan.messages.push(msg);
-        client.emit('msg', {
-            chan: chan.id,
-            msg: msg
-        });
-
-        var link = links[0];
-        fetch(link, function(res) {
-            parse(msg, link, res, client);
-        });
-    });
-};
-
-function parse(msg, url, res, client) {
-    var toggle = msg.toggle = {
-        id: msg.id,
-        type: '',
-        head: '',
-        body: '',
-        thumb: '',
-        link: url
-    };
-
-    switch (res.type) {
-    case 'text/html':
-        var $ = cheerio.load(res.text);
-        toggle.type = 'link';
-        toggle.head = $('title').text();
-        toggle.body =
-            $('meta[name=description]').attr('content') ||
-            $('meta[property=\'og:description\']').attr('content') ||
-            'No description found.';
-        toggle.thumb =
-            $('meta[property=\'og:image\']').attr('content') ||
-            $('meta[name=\'twitter:image:src\']').attr('content') ||
-            '';
-        break;
-
-    case 'image/png':
-    case 'image/gif':
-    case 'image/jpg':
-    case 'image/jpeg':
-        toggle.type = 'image';
-        break;
-
-    default:
-        return;
-    }
-
-    client.emit('toggle', toggle);
-}
 
 function fetch(url, cb) {
     var req = null;
@@ -142,4 +54,90 @@ function fetch(url, cb) {
             };
             cb(param);
         }));
+}
+
+function parse(msg, url, res, client) {
+    var toggle = msg.toggle = {
+        id: msg.id,
+        type: '',
+        head: '',
+        body: '',
+        thumb: '',
+        link: url
+    };
+
+    switch (res.type) {
+    case 'text/html':
+        var $ = cheerio.load(res.text);
+        toggle.type = 'link';
+        toggle.head = $('title').text();
+        toggle.body =
+            $('meta[name=description]').attr('content') ||
+            $('meta[property=\'og:description\']').attr('content') ||
+            'No description found.';
+        toggle.thumb =
+            $('meta[property=\'og:image\']').attr('content') ||
+            $('meta[name=\'twitter:image:src\']').attr('content') ||
+            '';
+        break;
+
+    case 'image/png':
+    case 'image/gif':
+    case 'image/jpg':
+    case 'image/jpeg':
+        toggle.type = 'image';
+        break;
+
+    default:
+        return;
+    }
+
+    client.emit('toggle', toggle);
+}
+
+export default function(irc, network) {
+    var client = this;
+    irc.on('message', function(data) {
+        var config = Helper.getConfig();
+        if (!config.prefetch) {
+            return;
+        }
+
+        var links = [];
+        var split = data.message.split(' ');
+        _.each(split, function(w) {
+            if (w.match(/^(http|https):\/\/localhost/g)) {
+                return;
+            }
+            var match = w.indexOf('http://') === 0 || w.indexOf('https://') === 0;
+            if (match) {
+                links.push(w);
+            }
+        });
+
+        if (links.length === 0) {
+            return;
+        }
+
+        var self = data.to.toLowerCase() === irc.me.toLowerCase();
+        var chan = _.findWhere(network.channels, {name: self ? data.from : data.to});
+        if (typeof chan === 'undefined') {
+            return;
+        }
+
+        var msg = new Msg({
+            type: MessageType.TOGGLE,
+            time: ''
+        });
+        chan.messages.push(msg);
+        client.emit('msg', {
+            chan: chan.id,
+            msg: msg
+        });
+
+        var link = links[0];
+        fetch(link, function(res) {
+            parse(msg, link, res, client);
+        });
+    });
 }

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,13 +1,11 @@
-'use strict';
+import _ from 'lodash';
+import Chan from '../../models/Channel';
+import Hostmask from '../../models/Hostmask';
+import ChannelType from '../../models/ChannelType';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Chan = require('../../models/Channel');
-var Hostmask = require('../../models/Hostmask');
-var ChannelType = require('../../models/ChannelType');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('message', function(data) {
         if (data.message.indexOf('\u0001') === 0 && data.message.substring(0, 7) !== '\u0001ACTION') {
@@ -70,4 +68,4 @@ module.exports = function(irc, network) {
             msg: msg
         });
     });
-};
+}

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('mode', function(data) {
         var chan = _.findWhere(network.channels, {name: data.target});
@@ -34,4 +32,4 @@ module.exports = function(irc, network) {
             });
         }
     });
-};
+}

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -1,9 +1,7 @@
-'use strict';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('motd', function(data) {
         var lobby = network.channels[0];
@@ -19,4 +17,4 @@ module.exports = function(irc, network) {
             });
         });
     });
-};
+}

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -1,9 +1,7 @@
-'use strict';
+import _ from 'lodash';
+import User from '../../models/User';
 
-var _ = require('lodash');
-var User = require('../../models/User');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('names', function(data) {
         var chan = _.findWhere(network.channels, {name: data.channel});
@@ -20,4 +18,4 @@ module.exports = function(irc, network) {
             users: chan.users
         });
     });
-};
+}

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('nick', function(data) {
         var self = false;
@@ -50,4 +48,4 @@ module.exports = function(irc, network) {
             });
         });
     });
-};
+}

--- a/src/plugins/irc-events/notice.js
+++ b/src/plugins/irc-events/notice.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('notice', function(data) {
         var target = data.to;
@@ -32,4 +30,4 @@ module.exports = function(irc, network) {
             msg: msg
         });
     });
-};
+}

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('part', function(data) {
         var chan = _.findWhere(network.channels, {name: data.channels[0]});
@@ -37,4 +35,4 @@ module.exports = function(irc, network) {
             });
         }
     });
-};
+}

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('quit', function(data) {
         network.channels.forEach(function(chan) {
@@ -30,4 +28,4 @@ module.exports = function(irc, network) {
             });
         });
     });
-};
+}

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -1,10 +1,8 @@
-'use strict';
+import _ from 'lodash';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('topic', function(data) {
         var chan = _.findWhere(network.channels, {name: data.channel});
@@ -35,4 +33,4 @@ module.exports = function(irc, network) {
             topic: chan.topic
         });
     });
-};
+}

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -1,9 +1,7 @@
-'use strict';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('welcome', function(data) {
         network.connected = true;
@@ -24,4 +22,4 @@ module.exports = function(irc, network) {
             nick: nick
         });
     });
-};
+}

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -1,12 +1,10 @@
-'use strict';
+import _ from 'lodash';
+import Chan from '../../models/Channel';
+import ChannelType from '../../models/ChannelType';
+import Msg from '../../models/Message';
+import MessageType from '../../models/MessageType';
 
-var _ = require('lodash');
-var Chan = require('../../models/Channel');
-var ChannelType = require('../../models/ChannelType');
-var Msg = require('../../models/Message');
-var MessageType = require('../../models/MessageType');
-
-module.exports = function(irc, network) {
+export default function(irc, network) {
     var client = this;
     irc.on('whois', function(err, data) {
         if (!!err) {
@@ -52,4 +50,4 @@ module.exports = function(irc, network) {
             });
         }
     });
-};
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,21 +1,20 @@
-'use strict';
-
-var _ = require('lodash');
-var assign = require('object-assign');
-var bcrypt = require('bcrypt-nodejs');
-var Client = require('./client');
-var ClientManager = require('./clientManager');
-var express = require('express');
-var fs = require('fs');
-var server = require('http');
-var io = require('socket.io');
-var Helper = require('./helper');
+/*eslint-disable block-scoped-var */
+import _ from 'lodash';
+import assign from 'object-assign';
+import bcrypt from 'bcrypt-nodejs';
+import Client from './client';
+import ClientManager from './clientManager';
+import express from 'express';
+import fs from 'fs';
+import server from 'http';
+import io from 'socket.io';
+import Helper from './helper';
 var config = {};
 
 var sockets = null;
 var manager = new ClientManager();
 
-module.exports = function(options) {
+export default function(options) {
     config = Helper.getConfig();
     config = assign(config, options);
 
@@ -69,7 +68,7 @@ module.exports = function(options) {
             manager.autoload();
         }
     }
-};
+}
 
 function index(req, res, next) {
     if (req.url.split('?')[0] !== '/') {


### PR DESCRIPTION
This patch introduces ES6 modules.
For static `require`, we use `import/export` syntax.
For dynamic `require`, we keep using `require`.

Fix #69 