### PR TITLE
Show twitter image based on customized atig

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -558,6 +558,14 @@ button {
 	width: 134px;
 	min-width: 134px;
 }
+#chat .from .user {
+    height: 16px;
+}
+#chat .from .user-image {
+    height: 16px;
+    width: 16px;
+    vertical-align: text-bottom;
+}
 #chat a {
 	color: #84ce88;
 	color: #50a656;

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -5,7 +5,11 @@
 	</span>
 	<span class="from">
 		{{#if from}}
-		<button class="user" style="color: #{{stringcolor from}}">{{mode}}{{from}}</button>
+			<button class="user" style="color: #{{stringcolor from}}">{{mode}}{{from}}
+			{{#if userImage}}
+				<img src="{{userImage}}" class="user-image">
+			{{/if}}
+			</button>
 		{{/if}}
 	</span>
 	<span class="text">

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -181,7 +181,15 @@ module.exports = {
         // @type     string
         // @default  '#foo, #karen-irc'
         //
-        join: '#foo, #karen-irc'
+        join: '#foo, #karen-irc',
+
+        //
+        // Allow showing user image
+        //
+        // @type     boolean
+        // @default  false
+        //
+        allowUserImage: false
     },
 
     //

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import Chan from './models/Channel';
 import ChannelType from './models/ChannelType';
 import crypto from 'crypto';
 import fs from 'fs';

--- a/src/Client.js
+++ b/src/Client.js
@@ -137,7 +137,7 @@ export default class Client {
         stream.on('error', (e) => {
             console.log('Client#connect():\n' + e);
             stream.end();
-            var msg = new Message({
+            var msg = new Message(null, {
                 type: MessageType.ERROR,
                 text: 'Connection error.'
             });

--- a/src/Client.js
+++ b/src/Client.js
@@ -168,7 +168,8 @@ export default class Client {
             password: args.password,
             username: username,
             realname: realname,
-            commands: args.commands
+            commands: args.commands,
+            allowUserImage: args.allowUserImage
         });
 
         network.irc = irc;

--- a/src/models/Channel.js
+++ b/src/models/Channel.js
@@ -114,7 +114,7 @@ export default class Channal {
     toJSON() {
         let clone = _.clone(this);
         clone.messages = clone.messages.slice(-100);
-        clone.network = null;
+        clone.network = undefined;
         return clone;
     }
 }

--- a/src/models/Channel.js
+++ b/src/models/Channel.js
@@ -40,9 +40,10 @@ export default class Channal {
 
     /**
      *  @constructor
+     *  @param  {Network} network
      *  @param  {?} attr
      */
-    constructor(attr) {
+    constructor(network, attr) {
         let data = assign({
             id: id++,
             messages: [],
@@ -73,6 +74,9 @@ export default class Channal {
 
         /** @type   {Array}    */
         this.users = data.users;
+
+        /** @type   {Network}    */
+        this.network = network;
     }
 
     /**
@@ -110,6 +114,7 @@ export default class Channal {
     toJSON() {
         let clone = _.clone(this);
         clone.messages = clone.messages.slice(-100);
+        clone.network = null;
         return clone;
     }
 }

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
+import _ from 'lodash';
 import assign from 'object-assign';
 import moment from 'moment';
 import MessageType from './MessageType';
@@ -33,9 +33,10 @@ export default class Message {
 
     /**
      *  @constructor
+     *  @param  {?Channel} channel
      *  @param  {?} attr
      */
-    constructor(attr) {
+    constructor(channel, attr) {
         let data = assign({
             type: MessageType.MESSAGE,
             id: id++,
@@ -66,5 +67,14 @@ export default class Message {
 
         /** @type   {boolean}   */
         this.self = data.self;
+
+        /** @type   {?Channel}  */
+        this.channel = channel;
+    }
+
+    toJSON() {
+        let clone = _.clone(this);
+        clone.channel = null;
+        return clone;
     }
 }

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -29,6 +29,33 @@ import MessageType from './MessageType';
 
 let id = 0;
 
+/**
+ *  @param  {?Channel} channel
+ *  @param  {Message} message
+ *  @return {?string}
+ */
+function findUserImage (channel, message) {
+    if (!channel) {
+        return null;
+    }
+
+    if (message.type !== MessageType.MESSAGE) {
+        return null;
+    }
+
+    let network = channel.network;
+    if (!network.allowUserImage) {
+        return null;
+    }
+
+    let hostmask = message.hostmask;
+    if (!hostmask) {
+        return null;
+    }
+
+    return hostmask.hostname;
+}
+
 export default class Message {
 
     /**
@@ -44,7 +71,8 @@ export default class Message {
             time: moment().utc().format('HH:mm:ss'),
             from: '',
             mode: '',
-            self: false
+            self: false,
+            hostmask: null
         }, attr);
 
         /** @type   {MessageType}  */
@@ -70,6 +98,12 @@ export default class Message {
 
         /** @type   {?Channel}  */
         this.channel = channel;
+
+        /** @type   {?Hostmask} */
+        this.hostmask = data.hostmask;
+
+        /** @type   {?string}   */
+        this.userImage = findUserImage(channel, this);
     }
 
     toJSON() {

--- a/src/models/Message.js
+++ b/src/models/Message.js
@@ -108,7 +108,7 @@ export default class Message {
 
     toJSON() {
         let clone = _.clone(this);
-        clone.channel = null;
+        clone.channel = undefined;
         return clone;
     }
 }

--- a/src/models/Network.js
+++ b/src/models/Network.js
@@ -117,7 +117,7 @@ export default class Network {
         this.irc = data.irc;
 
         this.channels.unshift(
-            new Channel({
+            new Channel(this, {
                 name: this.name,
                 type: ChannelType.LOBBY
             })

--- a/src/models/Network.js
+++ b/src/models/Network.js
@@ -73,6 +73,7 @@ export default class Network {
             username: '',
             realname: '',
             channels: [],
+            allowUserImage: false,
             connected: false,
             id: id++,
             irc: null,
@@ -111,6 +112,9 @@ export default class Network {
         this.channels = data.channels;
 
         /** @type   {boolean}   */
+        this.allowUserImage = data.allowUserImage;
+
+        /** @type   {boolean}   */
         this.connected = data.connected;
 
         /** @type   {?} */
@@ -136,7 +140,8 @@ export default class Network {
             'password',
             'username',
             'realname',
-            'commands'
+            'commands',
+            'allowUserImage'
         ]);
         network.nick = (this.irc || {}).me;
         network.join = _.pluck(

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -24,7 +24,7 @@ export default function(network, chan, cmd, args) {
             const text = slap || args.join(' ');
             irc.action(chan.name, text);
 
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.ACTION,
                 from: irc.me,
                 text: text

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -5,7 +5,7 @@ export default function(irc, network) {
     const client = this;
     irc.on('errors', function(data) {
         const lobby = network.channels[0];
-        const msg = new Message({
+        const msg = new Message(lobby, {
             type: MessageType.ERROR,
             text: data.message,
         });

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -32,7 +32,7 @@ export default function(irc, network) {
         if (data.nick.toLowerCase() === irc.me.toLowerCase()) {
             self = true;
         }
-        const msg = new Message({
+        const msg = new Message(chan, {
             from: data.nick,
             type: MessageType.JOIN,
             self: self

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Chan from '../../models/Channel';
+import Channel from '../../models/Channel';
 import Message from '../../models/Message';
 import MessageType from '../../models/MessageType';
 import User from '../../models/User';
@@ -9,7 +9,7 @@ export default function(irc, network) {
     irc.on('join', function(data) {
         let chan = _.find(network.channels, {name: data.channel});
         if (typeof chan === 'undefined') {
-            chan = new Chan({
+            chan = new Channel(network, {
                 name: data.channel
             });
             network.channels.push(chan);

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -29,7 +29,7 @@ export default function(irc, network) {
             self = true;
         }
 
-        const msg = new Message({
+        const msg = new Message(chan, {
             type: MessageType.KICK,
             mode: mode,
             from: from,

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -131,7 +131,7 @@ export default function(irc, network) {
             return;
         }
 
-        const msg = new Message({
+        const msg = new Message(chan, {
             type: MessageType.TOGGLE,
             time: ''
         });

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -54,7 +54,7 @@ export default function(irc, network) {
         }
 
         const name = data.from;
-        const msg = new Message({
+        const msg = new Message(chan, {
             type: type || MessageType.MESSAGE,
             mode: chan.getMode(name),
             from: name,

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Chan from '../../models/Channel';
+import Channel from '../../models/Channel';
 import Hostmask from '../../models/Hostmask';
 import ChannelType from '../../models/ChannelType';
 import Message from '../../models/Message';
@@ -20,7 +20,7 @@ export default function(irc, network) {
 
         let chan = _.findWhere(network.channels, {name: target});
         if (typeof chan === 'undefined') {
-            chan = new Chan({
+            chan = new Channel(network, {
                 type: ChannelType.QUERY,
                 name: data.from
             });

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -21,7 +21,7 @@ export default function(irc, network) {
                 self = true;
             }
 
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.MODE,
                 mode: chan.getMode(from),
                 from: from,

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -6,7 +6,7 @@ export default function(irc, network) {
     irc.on('motd', function(data) {
         const lobby = network.channels[0];
         data.motd.forEach(function(text) {
-            const msg = new Message({
+            const msg = new Message(lobby, {
                 type: MessageType.MOTD,
                 text: text
             });

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -9,7 +9,7 @@ export default function(irc, network) {
         const nick = data.new;
         if (nick === irc.me) {
             const lobby = network.channels[0];
-            const msg = new Message({
+            const msg = new Message(lobby, {
                 text: 'You\'re now known as ' + nick,
             });
             lobby.messages.push(msg);
@@ -36,7 +36,7 @@ export default function(irc, network) {
                 chan: chan.id,
                 users: chan.users
             });
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.NICK,
                 from: data.nick,
                 text: nick,

--- a/src/plugins/irc-events/notice.js
+++ b/src/plugins/irc-events/notice.js
@@ -20,7 +20,7 @@ export default function(irc, network) {
             from = '';
         }
 
-        const msg = new Message({
+        const msg = new Message(chan, {
             type: MessageType.NOTICE,
             from: from,
             text: data.message

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -28,7 +28,7 @@ export default function(irc, network) {
                 users: chan.users
             });
 
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.PART,
                 mode: chan.getMode(from),
                 from: from

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -20,7 +20,7 @@ export default function(irc, network) {
                 users: chan.users
             });
 
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.QUIT,
                 mode: chan.getMode(from),
                 from: from

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -17,7 +17,7 @@ export default function(irc, network) {
         }
 
         const topic = data.topic;
-        const msg = new Message({
+        const msg = new Message(chan, {
             type: MessageType.TOPIC,
             mode: chan.getMode(from),
             from: from,

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -9,7 +9,7 @@ export default function(irc, network) {
 
         const lobby = network.channels[0];
         const nick = data;
-        const msg = new Message({
+        const msg = new Message(lobby, {
             text: 'You\'re now known as ' + nick
         });
 

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Chan from '../../models/Channel';
+import Channel from '../../models/Channel';
 import ChannelType from '../../models/ChannelType';
 import Message from '../../models/Message';
 import MessageType from '../../models/MessageType';
@@ -17,7 +17,7 @@ export default function(irc, network) {
 
         let chan = _.findWhere(network.channels, {name: data.nickname});
         if (typeof chan === 'undefined') {
-            chan = new Chan({
+            chan = new Channel(network, {
                 type: ChannelType.QUERY,
                 name: data.nickname
             });

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -41,7 +41,7 @@ export default function(irc, network) {
                 continue;
             }
 
-            const msg = new Message({
+            const msg = new Message(chan, {
                 type: MessageType.WHOIS,
                 from: data.nickname,
                 text: key + ' ' + data[k]


### PR DESCRIPTION
When the configuration `allowUserImage` in network is enabled, it is set in `Network` model.
And `Message` model looks up the possible `userImage` from `Hostmask` model when assigned `Network` model's `allowUserImage` option is enabled.

Serialized `Message` model contains `userImage` and it will be used in client's `msg.tpl`.
This patch is intended to be used with the customized atig[[1]].
With this PR and the customized atig, we can show twitter profile image in the messages delivered from the twitter source.

The screenshot is the following.
![screenshot from 2015-05-04 04 51 23](https://cloud.githubusercontent.com/assets/9023/7446643/7da93fe2-f21a-11e4-98fa-8e65e4b06ac9.png)

[1]: https://github.com/Constellation/atig/commit/33703b6d3312e94b46e185a516ed5a327e33fa5c