### PR TITLE
Specify overflow-y: auto to sidebar to roll back scrolling functionality

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -135,7 +135,7 @@ button {
 	bottom: 52px;
 	left: 0;
 	overflow: hidden;
-	/*overflow-y: auto;*/
+	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Scrolling functionality of sidebar is implemented by TrackpadScrollEmulator.
Now, it's dropped in #113. So need to specify `overflow-y: auto`
to give scrolling functionality to sidebar.