### PR TITLE
Import babel polyfill

### DIFF
--- a/client/js/karen.js
+++ b/client/js/karen.js
@@ -1,5 +1,6 @@
 /*global $:true, Handlebars:true, moment: true */
 
+import 'babelify/polyfill';
 import AudioDriver from '../script/adopter/AudioDriver';
 import CommandTypeMod from '../script/model/CommandType';
 import CookieDriver from '../script/adopter/CookieDriver';


### PR DESCRIPTION
To allow using Symbol for `for-of`, importing babel polyfill is needed.
Close #123.