### PR TITLE
Disable some transforms for server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,6 +139,7 @@ gulp.task('__babel:server', ['clean:server'], function () {
                 'es6.classes',
                 'es6.constants',
                 'es6.forOf',
+                'es6.properties.shorthand',
                 'es6.templateLiterals',
             ],
             sourceMaps: false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -136,6 +136,7 @@ gulp.task('__babel:server', ['clean:server'], function () {
             // For io.js, we need not some transforms:
             blacklist: [
                 'es6.blockScoping',
+                'es6.classes',
                 'es6.constants',
                 'es6.forOf',
                 'es6.templateLiterals',


### PR DESCRIPTION
[iojs v2.0.0](https://github.com/iojs/io.js/blob/master/CHANGELOG.md#2015-05-04-version-200-rvagg) native support some ES6 features. so we can use them without [transforms](https://babeljs.io/docs/usage/transformers/).