### PR TITLE
Remove the feature: if you don't select any text and click a message, focus the input box when you're in desktop

### DIFF
--- a/client/js/karen.js
+++ b/client/js/karen.js
@@ -399,23 +399,6 @@ $(function() {
         });
     });
 
-    chat.on('click', '.messages', function() {
-        setTimeout(function() {
-            var text = '';
-            if (window.getSelection) {
-                text = window.getSelection().toString();
-            } else if (document.selection && document.selection.type !== 'Control') {
-                text = document.selection.createRange().text;
-            }
-            if (!text) {
-                var chan = chat.find('.active');
-                if (screen.width > 768 && chan.hasClass('chan')) {
-                    UIActionCreator.focusInputBox();
-                }
-            }
-        }, 2);
-    });
-
     $(window).on('focus', function () {
         var chan = chat.find('.active');
         if (screen.width > 768 && chan.hasClass('chan')) {


### PR DESCRIPTION
This removed feature was the following behavior:

## When

these are _and (&&)_ preconditions
- if you don't select any text and click a message.
- If you're in desktop mode.

## What to do

- focus the input box.

## Intent to remove

I don't feel this is good behavior for user. Even if the desktop usecase, I feel this is too meddlesome.