### PR TITLE
Fix regression by #141: cannot send message if you press enter key in input box.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -875,7 +875,7 @@ button {
     -webkit-appearance: none;
     width: 100%;
 }
-#form #submit {
+#form .submit {
     background: #f4f4f4;
     background-image: linear-gradient(#f4f4f4, #ececec);
     border: 1px solid #d7d7d7;

--- a/client/index.html
+++ b/client/index.html
@@ -272,7 +272,7 @@
             </div>
             <form id="form" action="">
                 <div class="inner">
-                    <button id="submit" type="submit">
+                    <button class="submit" type="submit">
                         Send
                     </button>
                     <div class="input">

--- a/client/js/karen.js
+++ b/client/js/karen.js
@@ -382,7 +382,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
     $(input).history()
             .tab(complete, {hint: false});
 
-    document.getElementById('form').addEventListener('submit', function (aEvent) {
+    $(document.getElementById('form')).on('submit', function (aEvent) {
         aEvent.preventDefault();
 
         const text = input.value;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -135,7 +135,7 @@ QUIT #d0907d
 }
 /* Hide unnecessary buttons */
 #windows .header .button,
-#form #submit {
+#form .submit {
   display: none;
 }
 

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -151,7 +151,7 @@ QUIT #bc6c4c
 
 /* Hide unnecessary buttons */
 #windows .header .button,
-#form #submit {
+#form .submit {
   display: none;
 }
 


### PR DESCRIPTION
jQuery input history plugin supresses 'keydown' events by default.
This behavior don't cause 'submit' event.

Why did the previous jquery code worked? 
jQuery input history plugin call jQuery.submit(). This method dispatches 'submit' jQuery DOM event, but its event don't propagate to plain DOM event system :(

Thus I rollback this code to the previous one to handle jQuery 'submit' DOM event. However, absolutely, I'll remove this plugin absolutely, absolutely, absolutely.