### PR TITLE
Update ESLint to 0.21.x via gulp-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,7 @@
             "after": true
         }],
         "comma-style": [2, "last"],
+        "linebreak-style": [2, "unix"],
         "no-mixed-spaces-and-tabs": 2,
         "no-underscore-dangle": 0,
         "operator-linebreak": [2, "after"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
         "comma-style": [2, "last"],
         "linebreak-style": [2, "unix"],
         "no-mixed-spaces-and-tabs": 2,
+        "no-unneeded-ternary": 2,
         "no-underscore-dangle": 0,
         "operator-linebreak": [2, "after"],
         "quotes": [2, "single", "avoid-escape"],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('__browserify', ['clean:client'], function () {
 
     const option = {
         insertGlobals: false,
-        debug: isRelease ? false : true,
+        debug: !isRelease,
     };
 
     const babel = babelify.configure({

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",
     "gulp-concat": "^2.5.2",
-    "gulp-eslint": "^0.11.1",
+    "gulp-eslint": "^0.12.0",
     "gulp-handlebars": "^4.0.0",
     "gulp-uglifyjs": "^0.6.1",
     "handlebars": "^2.0.0",


### PR DESCRIPTION
## Added options

- [linebreak-style](http://eslint.org/docs/rules/linebreak-style)
- [no-unneeded-ternary](http://eslint.org/docs/rules/no-unneeded-ternary)

## Not added
- [dot-location](http://eslint.org/docs/rules/dot-location)
- `skipBlankLines` option of the [no-trailing-spaces](http://eslint.org/docs/rules/no-trailing-spaces) option.