### PR TITLE
Use forked engine.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rx": "^2.5.2",
     "slate-irc": "karen-irc/slate-irc.git#b12d540fa231b64e4e012c9e29412a2dc448acbe",
     "socket.io": "^1.3.5",
+    "engine.io": "karen-irc/engine.io.git#d0e03b6826935ba17383419a6ed0c465bf8dcab8",
     "socket.io-client": "^1.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
engine.io with `httpCompress` is not sipped yet.
To work around it, we forked engine.io and indicate it directly in
karen's package.json.

Close #168