### PR TITLE
Use let for for-of statement

### DIFF
--- a/server/ClientManager.js
+++ b/server/ClientManager.js
@@ -14,7 +14,7 @@ import Rx from 'rx';
  */
 const pluckFromSet = function (set, path) {
     const result = [];
-    for (const item of set) {
+    for (let item of set) {
         if ( item[path] !== undefined ) {
             const value = item[path];
             result.push(item);
@@ -33,7 +33,7 @@ const pluckFromSet = function (set, path) {
 const difference = function (a, b) {
     const diff = [];
     const base = new Set(b);
-    for (const item of a) {
+    for (let item of a) {
         if (!base.has(item)) {
             diff.push(item);
         }

--- a/server/plugins/irc-events/whois.js
+++ b/server/plugins/irc-events/whois.js
@@ -35,7 +35,7 @@ export default function(irc, network) {
             server: 'using'
         };
 
-        for (const k in data) {
+        for (let k in data) {
             const key = prefix[k];
             if (!key || data[k].toString() === '') {
                 continue;


### PR DESCRIPTION
It incurs syntax errors with io.js 2.0.1.
Since babel generated for-of + non-transformed `const` makes incorrect js.