### PR TITLE
Quick fix: babel's 'es6.forOf' blacklisting don't work.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,7 @@
 /*eslint-disable block-scoped-var */
+
+require('babelify/polyfill');
+
 import _ from 'lodash';
 import assign from 'object-assign';
 import bcrypt from 'bcrypt-nodejs';


### PR DESCRIPTION
Its wrong behavior will cause the following error.

```sh
ReferenceError: regeneratorRuntime is not defined
    at Client.find (/Users/tetsuharu/src/karen/dist/Client.js:119:35)
    at Client.open (/Users/tetsuharu/src/karen/dist/Client.js:267:27)
    at AnonymousObserver._onNext (/Users/tetsuharu/src/karen/dist/server.js:148:20)
    at AnonymousObserver.Rx.AnonymousObserver.AnonymousObserver.next (/Users/tetsuharu/src/karen/node_modules/rx/dist/rx.js:1962:12)
    at AnonymousObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/Users/tetsuharu/src/karen/node_modules/rx/dist/rx.js:1894:35)
    at AnonymousObserver.tryCatcher (/Users/tetsuharu/src/karen/node_modules/rx/dist/rx.js:567:29)
    at AutoDetachObserverPrototype.next (/Users/tetsuharu/src/karen/node_modules/rx/dist/rx.js:5018:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/Users/tetsuharu/src/karen/node_modules/rx/dist/rx.js:1894:35)
    at Socket.<anonymous> (/Users/tetsuharu/src/karen/dist/adapter/ClientSocketDriver.js:116:26)
    at emitOne (events.js:77:13)
```