### PR TITLE
Cache node.js dependencies in travis CI side

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ notifications:
 branches:
   only:
     - auto
+
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Follow the official article[1].
It reduces test time and makes commit-queue system confortable.

[1]: http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/235)
<!-- Reviewable:end -->
