### PR TITLE
Add branch blacklist for "tmp" branch in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ notifications:
   email: false
   webhooks: http://utatane.softether.net:10800/travis
 
+# blacklist
+branches:
+  except:
+    - tmp
+
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
This branch is used in homu. And should not run CI.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/237)
<!-- Reviewable:end -->
