### PR TITLE
Remove needless bootstrap tooltip

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -33,10 +33,10 @@
             </div>
         </aside>
         <footer id="footer">
-            <button class="icon sign-in" data-target="#sign-in" data-title="Sign in" data-placement="top" title="Sign in to karen"></button>
-            <button class="icon connect" data-target="#connect" data-title="Connect" data-placement="top" title="Connect to network"></button>
-            <button class="icon settings" data-target="#settings" data-title="Settings" data-placement="top" title="Client settings"></button>
-            <button id="sign-out" class="icon sign-out" data-placement="top" title="Sign out"></button>
+            <button class="icon sign-in" data-target="#sign-in" title="Sign in to karen"></button>
+            <button class="icon connect" data-target="#connect" title="Connect to network"></button>
+            <button class="icon settings" data-target="#settings" title="Client settings"></button>
+            <button id="sign-out" class="icon sign-out" title="Sign out"></button>
         </footer>
         <div id="main">
             <div id="windows">

--- a/client/script/karen.ts
+++ b/client/script/karen.ts
@@ -121,8 +121,6 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
         document.documentElement.classList.add('web-app-mode');
     }
 
-    $('#footer .icon').tooltip();
-
     function render(name: string, data: any): string {
         return Handlebars.templates[name](data);
     }


### PR DESCRIPTION
This feature needs a mouse over action, but there is no mouse over in touch devices....
I don't think this is good feature. We should use more explicit labeling.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/244)
<!-- Reviewable:end -->
