### PR TITLE
Support TSX (fb::JSX syntax in TypeScript)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 end_of_line = lf
 charset = utf-8
 
-[*.{js,ts,html,css}]
+[*.{js,ts,jsx,tsx,html,css}]
 indent_style = space
 indent_size = 4
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,6 +105,7 @@ gulp.task('__browserify', ['clean:client', '__cp_client', '__typescript'], funct
     const option = {
         insertGlobals: false,
         debug: !isRelease,
+        extensions: ['.jsx'],
     };
 
     const babel = babelify.configure({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "jsx": "preserve",
         "noImplicitAny": true,
         "suppressImplicitAnyIndexErrors": true,
         "removeComments": false,


### PR DESCRIPTION
We use the option `--jsx preserve` of TypeScript Compiler because we'll unify the jsx transformer into babel.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/263)
<!-- Reviewable:end -->
