### PR TITLE
Switch to the npm published nightly of TypeScript compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mocha": "^2.2.4",
     "object-assign": "^3.0.0",
     "tsd": "^0.6.0-beta.5",
-    "typescript": "Microsoft/TypeScript.git#649e40b1711096de54eb325a702597d3ee62e9ef",
+    "typescript": "1.6.0-dev.20150723",
     "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
After [this](https://github.com/Microsoft/TypeScript/pull/3875), it looks like that Microsoft TypeScript team began to publish nightly build of TypeScript compiler.

Fetching from npm is a little faster than fetching from git revision from the repository, so we'll switch to it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/280)
<!-- Reviewable:end -->
