### PR TITLE
Update ESLint to 1.2.x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,6 +101,7 @@
         }],
         "no-class-assign": 2,
         "no-const-assign": 2,
+        "no-dupe-class-members": 2,
         "no-this-before-super": 2,
         "no-var": 1,
         "object-shorthand": 0,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test": "npm run lint && npm run unit-test",
     "lint": "gulp jslint",
     "unit-test": "mocha test/**/*.js",
-
     "gulp": "gulp"
   },
   "keywords": [
@@ -50,6 +49,7 @@
     "compression": "^1.4.3",
     "cookies-js": "^1.2.1",
     "core-js": "^1.0.1",
+    "eslint": "^1.2.0",
     "event-stream": "^3.1.7",
     "express": "^4.9.5",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
http://eslint.org/blog/2015/08/eslint-1.2.0-released/

New Enabled:

http://eslint.org/docs/rules/no-dupe-class-members

I feel the following rules are just stylistic rules.
So we don't enable these:

- http://eslint.org/docs/rules/block-spacing
- http://eslint.org/docs/rules/prefer-arrow-callback
- http://eslint.org/docs/rules/prefer-template

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/313)
<!-- Reviewable:end -->
