### PR TITLE
[client] a new selected tab should be published on the next event loop.

### DIFF
--- a/client/script/domain/DomainState.ts
+++ b/client/script/domain/DomainState.ts
@@ -74,9 +74,12 @@ export class DomainState {
 
         this._networkSet = new NetworkSetDomain(gateway);
         this._latestCurrentTab = null;
+
+        // In most of case, a rendering operation is depend on the source of `selectTab()`.
+        // So this observable should be on the next event loop.
         this._currentTab = selectTab(gateway, UIActionCreator.getDispatcher(), this._networkSet).do((state) => {
             this._latestCurrentTab = state;
-        }).share();
+        }).observeOn(Rx.Scheduler.default).share();
     }
 
     get currentTab(): SelectedTab {

--- a/client/script/output/view/SidebarViewController.ts
+++ b/client/script/output/view/SidebarViewController.ts
@@ -72,7 +72,7 @@ export default class SidebarViewController implements EventListenerObject {
 
         // This should be scheduled on the next event loop
         // bacause to wait to complete other tasks.
-        this._disposeSelectChannel = domain.getSelectedChannel().observeOn(Rx.Scheduler.default).subscribe((channelId) => {
+        this._disposeSelectChannel = domain.getSelectedChannel().subscribe((channelId) => {
             this.selectChannel(channelId);
         });
 


### PR DESCRIPTION
In most of case, a rendering operation is depend on the source of `selectTab()`. So this observable should be on the next event loop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/323)
<!-- Reviewable:end -->
