### PR TITLE
Revert "Remove the needless reference path for option-t"

### DIFF
--- a/client/script/domain/DomainState.ts
+++ b/client/script/domain/DomainState.ts
@@ -24,6 +24,7 @@
  */
 
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
+/// <reference path="../../../node_modules/option-t/option-t.d.ts" />
 
 import {Some, None, Option} from 'option-t';
 import * as Rx from 'rx';

--- a/client/script/domain/Network.ts
+++ b/client/script/domain/Network.ts
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 
+/// <reference path="../../../node_modules/option-t/option-t.d.ts" />
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
 import * as Rx from 'rx';

--- a/client/script/domain/NetworkDomain.ts
+++ b/client/script/domain/NetworkDomain.ts
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 
+/// <reference path="../../../node_modules/option-t/option-t.d.ts" />
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
 // babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.

--- a/client/script/karen.ts
+++ b/client/script/karen.ts
@@ -3,6 +3,7 @@
 /// <reference path="../../tsd/core-js.d.ts" />
 /// <reference path="../../tsd/extends.d.ts" />
 /// <reference path="../../node_modules/rx/ts/rx.all.es6.d.ts" />
+/// <reference path="../../node_modules/option-t/option-t.d.ts" />
 /// <reference path="../../tsd/third_party/jquery/jquery.d.ts" />
 /// <reference path="../../tsd/third_party/jqueryui/jqueryui.d.ts" />
 /// <reference path="../../tsd/third_party/react/react.d.ts" />

--- a/client/script/output/WindowPresenter.ts
+++ b/client/script/output/WindowPresenter.ts
@@ -24,6 +24,7 @@
  */
 
 /// <reference path="../../../tsd/core-js.d.ts" />
+/// <reference path="../../../node_modules/option-t/option-t.d.ts" />
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
 import * as Rx from 'rx';


### PR DESCRIPTION
- This reverts commit df91c99f37b1910d8817ee724ab24970286494df (#333)
- Visual Studio Code v0.8 preview cannot recognize the node modules without the reference path.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/335)
<!-- Reviewable:end -->
