### PR TITLE
Stop to load polyfills for Symbol & es6.array.iterator

### DIFF
--- a/client/script/domain/Network.ts
+++ b/client/script/domain/Network.ts
@@ -26,9 +26,6 @@
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
 import * as Rx from 'rx';
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
 
 import Channel from './Channel';
 import {Some, None, Option} from 'option-t';

--- a/client/script/domain/NetworkDomain.ts
+++ b/client/script/domain/NetworkDomain.ts
@@ -26,10 +26,6 @@
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 /// <reference path="../../../node_modules/typescript/lib/lib.es6.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import {Some, None, Option} from 'option-t';
 import * as Rx from 'rx';
 

--- a/client/script/domain/NetworkSet.ts
+++ b/client/script/domain/NetworkSet.ts
@@ -25,10 +25,6 @@
 
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import Channel from './Channel';
 import Network from './Network';
 import * as Rx from 'rx';

--- a/client/script/domain/NetworkSetDomain.ts
+++ b/client/script/domain/NetworkSetDomain.ts
@@ -26,10 +26,6 @@
 /// <reference path="../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 /// <reference path="../../../node_modules/typescript/lib/lib.es6.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import {Some, None, Option} from 'option-t';
 import * as Rx from 'rx';
 

--- a/client/script/karen.ts
+++ b/client/script/karen.ts
@@ -7,10 +7,6 @@
 /// <reference path="../../tsd/third_party/react/react.d.ts" />
 /// <reference path="../../tsd/react.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import {Some, None, Option} from 'option-t';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';

--- a/client/script/output/view/SignInViewController.ts
+++ b/client/script/output/view/SignInViewController.ts
@@ -26,10 +26,6 @@
 
 /// <reference path="../../../../tsd/third_party/jquery/jquery.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import CookieDriver from '../../adapter/CookieDriver';
 import {SocketIoDriver} from '../../adapter/SocketIoDriver';
 

--- a/client/script/output/viewmodel/SettingStore.ts
+++ b/client/script/output/viewmodel/SettingStore.ts
@@ -25,10 +25,6 @@
 
 /// <reference path="../../../../node_modules/rx/ts/rx.all.es6.d.ts" />
 
-// babel's `es6.forOf` transform uses `Symbol` and 'Array[Symbol.iterator]'.
-import 'core-js/modules/es6.array.iterator';
-import 'core-js/es6/symbol';
-
 import ConfigRepository from '../../adapter/ConfigRepository';
 import * as Rx from 'rx';
 import Setting from '../../domain/Setting';

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "commander": "^2.3.0",
     "compression": "^1.4.3",
     "cookies-js": "^1.2.2",
-    "core-js": "^1.0.1",
     "event-stream": "^3.1.7",
     "express": "^4.9.5",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
- Now, They are supported in:
  - Microsoft Edge
  - Firefox
  - Chromium
  - Safari 9
- We don't have any usecases of core-js, so we remove it from package.json.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/384)
<!-- Reviewable:end -->
