### PR TITLE
client: stop to transform some es6 syntax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,6 +121,7 @@ gulp.task('__browserify', ['__clean:client:js', '__cp:client:js', '__typescript'
     const babel = babelify.configure({
         optional: babelOptions,
         blacklist: [
+            'es6.forOf',
             'es6.templateLiterals',
         ],
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,6 +120,9 @@ gulp.task('__browserify', ['__clean:client:js', '__cp:client:js', '__typescript'
 
     const babel = babelify.configure({
         optional: babelOptions,
+        blacklist: [
+            'es6.templateLiterals',
+        ],
     });
 
     return browserify(ENTRY_POINT, option)


### PR DESCRIPTION
This stop to use some transform paths of es6 syntax which are needless for our targets (Edge, Firefox, Chromium, Safari 9)

http://kangax.github.io/compat-table/es6/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/432)
<!-- Reviewable:end -->
