### PR TITLE
Remove to handle 'navigator.standalone'.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -37,9 +37,6 @@ button {
     outline: none;
     background: none;
 }
-.web-app-mode {
-    padding-top: 20px;
-}
 .tooltip-inner {
     border-radius: 2px;
     background: #fff;

--- a/client/script/karen.ts
+++ b/client/script/karen.ts
@@ -61,10 +61,6 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
     const sidebar = $('#sidebar');
     const chat = $('#chat');
 
-    if (navigator.standalone) {
-        document.documentElement.classList.add('web-app-mode');
-    }
-
     socket.error().subscribe(function(e: any) {
         /*eslint-disable no-console*/
         console.log(e);

--- a/tsd/extends.d.ts
+++ b/tsd/extends.d.ts
@@ -36,7 +36,6 @@ declare module ExtendedExistedInterface {
 }
 
 interface Navigator {
-    standalone: boolean;
 }
 
 interface JQuery {


### PR DESCRIPTION
This non-standard property is set if `meta[name="apple-mobile-web-app-capable"]` is `content="yes"`.
But it is removed in #423 (and does not work in iOS9), so we think this code would not work well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/436)
<!-- Reviewable:end -->
