### PR TITLE
Execute 'npm prune' after 'npm install' in TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: node_js
 
+install:
+  - npm install
+  - npm prune
+
 before_script:
   - node_modules/.bin/gulp default
   - ./index.js init


### PR DESCRIPTION
Now, our TravisCI config caches packages.
So this change prune needless packages appropriately.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/458)
<!-- Reviewable:end -->
