### PR TITLE
Enable 'npm dedup' on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: node_js
 install:
   - npm install
   - npm prune
+  - npm dedup
 
 before_script:
   - node_modules/.bin/gulp default


### PR DESCRIPTION
npm mistakes mistakes to install duplicated packages.
e.g. babel-related packages.

This causes sometimes a compile error.
(e.g. babel....)

so this change fix it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/463)
<!-- Reviewable:end -->
