### PR TITLE
Use tslint's stable channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "gulp-uglifyjs": "^0.6.2",
     "mocha": "^2.3.4",
     "tsd": "^0.6.5",
-    "tslint": "3.2.1-dev.1",
+    "tslint": "~3.2.1",
     "typescript": "1.8.0-dev.20160109",
     "vinyl-source-stream": "^1.1.0"
   }


### PR DESCRIPTION
- this causes install warning
- If tslint causes some conflicts with typescript compiler, then we move back to tslint's dev channel.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/536)
<!-- Reviewable:end -->
