### PR TITLE
feat(tslint): unify type assertion syntax with `as` syntax

### DIFF
--- a/src/client/rize/adapter/NotificationService.ts
+++ b/src/client/rize/adapter/NotificationService.ts
@@ -66,12 +66,12 @@ export class NotificationService {
 }
 
 function isNotificationGranted(): boolean {
-    return (<any>window).Notification.permission === 'granted';
+    return (window as any).Notification.permission === 'granted';
 }
 
 function requestPermittion(): Rx.Observable<boolean> {
     return Rx.Observable.create(function (o: Rx.Observer<boolean>) {
-        (<any>window).Notification.requestPermission(function (permission: string) {
+        (window as any).Notification.requestPermission(function (permission: string) {
             const isGranted = permission === 'granted';
             o.next(isGranted);
             o.complete();
@@ -80,7 +80,7 @@ function requestPermittion(): Rx.Observable<boolean> {
 }
 
 function showNotification(topic: NotifedTopic): Rx.Observable<void> {
-    let notification: Notification = new (<any>window).Notification(topic.title, {
+    let notification: Notification = new (window as any).Notification(topic.title, {
         body: topic.body,
         icon: topic.icon,
     });

--- a/src/client/rize/index.ts
+++ b/src/client/rize/index.ts
@@ -24,4 +24,4 @@
  */
 
 import {RizeClient} from './rize';
-(<any>window).gKarenClient = new RizeClient();
+(window as any).gKarenClient = new RizeClient();

--- a/src/client/script/adapter/MessageGateway.ts
+++ b/src/client/script/adapter/MessageGateway.ts
@@ -88,7 +88,7 @@ export class MessageGateway {
     invokeInit(): Rx.Observable<{ networks: Array<Network>; token: string; active: Option<ChannelId|string>; }> {
         return this._socket.init().map(function(data: any){
             const list = (data.networks.length !== 0) ?
-                (<Array<any>>data.networks).map(function(item){
+                (data.networks as Array<any>).map(function(item){
                     return new Network(item);
                 }) : [];
             return {
@@ -107,7 +107,7 @@ export class MessageGateway {
             const network = new NetworkConnectionValue(first.name, first.host, first.port,
                                                        first.passward, first.tls);
             const personal = new PersonalConnectionValue(first.nick, first.username, first.realname, first.join);
-            return <[NetworkConnectionValue, PersonalConnectionValue]>[network, personal];
+            return [network, personal] as [NetworkConnectionValue, PersonalConnectionValue];
         });
     }
 
@@ -180,13 +180,13 @@ export class MessageGateway {
 
     partFromChannel(): Rx.Observable<ChannelId> { // channelId
         return this._socket.part().map(function(data){
-            return <ChannelId>data.chan;
+            return data.chan as ChannelId;
         });
     }
 
     quitNetwork(): Rx.Observable<NetworkId> {
         return this._socket.quit().map(function(data) {
-            const id = <NetworkId>data.network;
+            const id = data.network as NetworkId;
             return id;
         });
     }

--- a/src/client/script/domain/CommandType.ts
+++ b/src/client/script/domain/CommandType.ts
@@ -54,6 +54,6 @@ export const CommandType = Object.freeze({
 });
 
 export const CommandList: Array<string> = Object.keys(CommandType).map(function(name: string): string {
-    return (<any>CommandType)[name];
+    return (CommandType as any)[name];
 });
 Object.freeze(CommandList);

--- a/src/client/script/domain/DomainState.ts
+++ b/src/client/script/domain/DomainState.ts
@@ -56,7 +56,7 @@ export class SelectedTab {
             return new None<ChannelId>();
         }
 
-        const id = parseInt(<any>this.id, 10);
+        const id = parseInt(this.id as any, 10);
         return new Some<ChannelId>(id);
     }
 }
@@ -120,7 +120,7 @@ export class DomainState {
         return this.getCurrentTab().filter(function(state){
             return state.type === CurrentTabType.SETTING;
         }).map(function(state){
-            return <string>state.id;
+            return state.id as string;
         });
     }
 

--- a/src/client/script/karen.ts
+++ b/src/client/script/karen.ts
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
             socket.emit('auth', {token: token.unwrap()});
         }
         if (body.classList.contains('signed-out')) {
-            const error = <HTMLElement>login.querySelector('.error');
+            const error = login.querySelector('.error') as HTMLElement;
             error.style.display = '';
             const form = login.querySelector('.container');
             form.addEventListener('submit', function onSubmit() {
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
         if (token.isNone) {
             body.classList.add('signed-out');
         }
-        const input = <HTMLInputElement>login.querySelector('input[name=\'user\']');
+        const input = login.querySelector('input[name=\'user\']') as HTMLInputElement;
         if (input.value === '') {
             input.value = auth.getUser().unwrapOr('');
         }
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
         });
         const html = ReactDOMServer.renderToStaticMarkup(view);
         const chan = document.getElementById('js-chan-' + target);
-        (<HTMLElement>chan.querySelector('.messages')).insertAdjacentHTML('afterbegin', html);
+        (chan.querySelector('.messages') as HTMLElement).insertAdjacentHTML('afterbegin', html);
         if (data.messages.length !== 100) {
             chan.querySelector('.show-more').classList.remove('show');
         }
@@ -239,7 +239,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
         }
 
         target.classList.add('active');
-        (<HTMLElement>target).style.zIndex = String(top++);
+        (target as HTMLElement).style.zIndex = String(top++);
 
         const channel = globalState.networkSet.getChannelById(id);
         const network = channel.map(function(channel: Channel){
@@ -270,7 +270,7 @@ document.addEventListener('DOMContentLoaded', function onLoad() {
         const evt = document.createEvent('CustomEvent');
         evt.initCustomEvent('show', true, true, null);
         target.dispatchEvent(evt);
-        (<HTMLElement>target).style.zIndex = String(top++);
+        (target as HTMLElement).style.zIndex = String(top++);
     });
 
     AppActionCreator.dispatcher().signout.subscribe(function(){

--- a/src/client/script/output/WindowPresenter.ts
+++ b/src/client/script/output/WindowPresenter.ts
@@ -98,13 +98,13 @@ export class WindowPresenter implements EventListenerObject {
     handleEvent(event: Event): void {
         switch (event.type) {
             case 'resize':
-                this.onResize(<UIEvent>event);
+                this.onResize(event as UIEvent);
                 break;
             case 'keydown':
-                this.onKeydown(<KeyboardEvent>event);
+                this.onKeydown(event as KeyboardEvent);
                 break;
             case 'focus':
-                this.onFocus(<FocusEvent>event);
+                this.onFocus(event as FocusEvent);
                 break;
         }
     }

--- a/src/client/script/output/view/AppView.ts
+++ b/src/client/script/output/view/AppView.ts
@@ -81,7 +81,7 @@ export class AppView implements EventListenerObject {
     }
 
     onClick(aEvent: Event): void {
-        const target = <Element>aEvent.target;
+        const target = aEvent.target as Element;
         if (!(target.localName === 'button')) {
             return;
         }

--- a/src/client/script/output/view/GeneralSettingView.ts
+++ b/src/client/script/output/view/GeneralSettingView.ts
@@ -61,13 +61,13 @@ export class GeneralSettingView implements EventListenerObject {
     }
 
     onChange(aEvent: Event): void {
-        const target = <Element>aEvent.target;
+        const target = aEvent.target as Element;
         if (target.localName !== 'input') {
             return;
         }
 
         const name = target.getAttribute('name');
-        const value = (<HTMLInputElement>target).checked;
+        const value = (target as HTMLInputElement).checked;
 
         SettingActionCreator.setOption(name, value);
 
@@ -81,7 +81,7 @@ export class GeneralSettingView implements EventListenerObject {
     }
 
     updateState(option: { name: string, value: any}): void {
-        const input = <HTMLInputElement>this._element.querySelector('input[name=' + option.name + ']');
+        const input = this._element.querySelector('input[name=' + option.name + ']') as HTMLInputElement;
         if (!input) {
             return;
         }

--- a/src/client/script/output/view/InputBoxView.ts
+++ b/src/client/script/output/view/InputBoxView.ts
@@ -69,8 +69,8 @@ export class InputBoxView {
         this._domain = domain;
         this._currentNetworkId = -1;
         this._currntChannel = new None<Channel>();
-        this._textInput = <HTMLInputElement>element.querySelector('#js-input');
-        this._nickElement = <HTMLElement>element.querySelector('#js-nick');
+        this._textInput = element.querySelector('#js-input') as HTMLInputElement;
+        this._nickElement = element.querySelector('#js-nick') as HTMLElement;
 
         const disposer = new Rx.Subscription();
         this._disposer = disposer;
@@ -117,7 +117,7 @@ export class InputBoxView {
                 this.onSubmit(aEvent);
                 break;
             case 'keydown':
-                this.onKeydown(<KeyboardEvent>aEvent);
+                this.onKeydown(aEvent as KeyboardEvent);
                 break;
             case 'input':
                 this.onInput(aEvent);

--- a/src/client/script/output/view/MainContentAreaView.ts
+++ b/src/client/script/output/view/MainContentAreaView.ts
@@ -69,8 +69,8 @@ export class MainContentAreaView {
 
         const networkDomain = domain.getNetworkDomain();
         disposer.add(networkDomain.joinedChannelAtAll().subscribe((channelDomain) => {
-            const fragment: Node = <Node>createChannelFragment(channelDomain);
-            const subtree = element = <Element>fragment.firstChild;
+            const fragment: Node = createChannelFragment(channelDomain) as Node;
+            const subtree = element = fragment.firstChild as Element;
             const view = new MessageContentView(channelDomain, subtree);
             const id = channelDomain.getId();
             this._channelMap.set(id, view);

--- a/src/client/script/output/view/MessageContentView.ts
+++ b/src/client/script/output/view/MessageContentView.ts
@@ -87,7 +87,7 @@ export class MessageContentView {
         }));
 
         disposer.add(Rx.Observable.fromEvent(this._messageArea, 'click').subscribe((event: Event) => {
-            const target = <Element>event.target;
+            const target = event.target as Element;
             if (target.classList.contains('toggle-button')) {
                 this._toggleInlineContentContainer(target);
                 UIActionCreator.toggleInlineImage();
@@ -173,7 +173,7 @@ export class MessageContentView {
 
     private _toggleInlineContentContainer(element: Element): void {
         const container = element.parentNode.nextSibling;
-        (<Element>container).classList.toggle('show');
+        (container as Element).classList.toggle('show');
     }
 }
 

--- a/src/client/script/output/view/SidebarFooterView.ts
+++ b/src/client/script/output/view/SidebarFooterView.ts
@@ -49,10 +49,10 @@ export class SidebarFooterView implements EventListenerObject {
 
     constructor(domain: DomainState, message: MessageGateway, element: Element) {
         this._element = element;
-        this._signinElement = <HTMLElement>element.querySelector('.sign-in');
-        this._signoutElement = <HTMLElement>element.querySelector('.sign-out');
-        this._connectElement = <HTMLElement>element.querySelector('.connect');
-        this._settingElement = <HTMLElement>element.querySelector('.settings');
+        this._signinElement = element.querySelector('.sign-in') as HTMLElement;
+        this._signoutElement = element.querySelector('.sign-out') as HTMLElement;
+        this._connectElement = element.querySelector('.connect') as HTMLElement;
+        this._settingElement = element.querySelector('.settings') as HTMLElement;
 
         this._lastSelectedElement = null;
 
@@ -109,7 +109,7 @@ export class SidebarFooterView implements EventListenerObject {
     }
 
     onClick(aEvent: Event): void {
-        const target = <Element>aEvent.target;
+        const target = aEvent.target as Element;
         if (target.localName !== 'button') {
             return;
         }

--- a/src/client/script/output/view/SignInView.ts
+++ b/src/client/script/output/view/SignInView.ts
@@ -58,13 +58,13 @@ export class SignInView implements EventListenerObject {
     }
 
     onShow(aEvent: Event): void {
-        const target = <Element>aEvent.currentTarget;
+        const target = aEvent.currentTarget as Element;
         // XXX: By DOM spec (https://dom.spec.whatwg.org/#interface-nodelist),
         // NodeList should be iterable<Node> and this means it has `Symbol.iterator`
         // by Web IDL spec (http://heycam.github.io/webidl/#idl-iterable).
         const list = target.querySelectorAll('input');
         for (let element of Array.from(list)) {
-            const input = <HTMLInputElement>element;
+            const input = element as HTMLInputElement;
             // If we find the element which has no value,
             // we stop iteration & focus it.
             if (input.value === '') {
@@ -75,7 +75,7 @@ export class SignInView implements EventListenerObject {
     }
 
     onSubmit(aEvent: Event): void {
-        const target = <Element>aEvent.target;
+        const target = aEvent.target as Element;
         if (target.localName !== 'form') {
             return;
         }
@@ -86,7 +86,7 @@ export class SignInView implements EventListenerObject {
         // by Web IDL spec (http://heycam.github.io/webidl/#idl-iterable).
         const list = target.querySelectorAll('.btn');
         for (let element of Array.from(list)) {
-            (<Element>element).setAttribute('disabled', 'true');
+            (element as Element).setAttribute('disabled', 'true');
         }
 
         const values: { user: string, [key: string]: any, } = {

--- a/src/client/script/output/viewmodel/SettingStore.ts
+++ b/src/client/script/output/viewmodel/SettingStore.ts
@@ -54,7 +54,7 @@ export class SettingStore {
             for (let key of keys) {
                 observer.next({
                     name: key,
-                    value: (<any>this._setting)[key],
+                    value: (this._setting as any)[key],
                 });
             }
             observer.complete();
@@ -74,7 +74,7 @@ export class SettingStore {
 
     update(name: string, value: any): void {
         const setting = this._setting;
-        (<any>setting)[name] = value;
+        (setting as any)[name] = value;
         this._repository.set(setting);
 
         this._subject.next({

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,7 @@
         "curly": true,
         "indent": [true, "spaces"],
         "member-ordering": [true, "variables-before-functions"],
-        "no-angle-bracket-type-assertion": false,
+        "no-angle-bracket-type-assertion": true,
         "no-arg": true,
         "no-conditional-assignment": true,
         "no-construct": true,


### PR DESCRIPTION
By historicaly, TypeScript has two type assertion syntax:

* `<Foo>Bar` is introduced from classically.a
* `Bar as Foo` is introduced with React JSX syntax.

At now, there are no recommendation style.

> The two samples are equivalent. Using one over the other is mostly a
> choice of preference; however, when using TypeScript with JSX, only
> as-style assertions are allowed.
> http://www.typescriptlang.org/docs/handbook/basic-types.html

But in this project, we unify them into `as` syntax.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/613)
<!-- Reviewable:end -->
