### PR TITLE
fix(eslint): include .eslintrc.js correctly

### DIFF
--- a/tools/build/lint.js
+++ b/tools/build/lint.js
@@ -40,7 +40,7 @@ function runESLint(cwd, nodeModDir) {
     const args = [
         bin,
         '--ext', '.js,.jsx',
-        '.',
+        '.', './**/.eslintrc.js',
     ];
 
     const option = {


### PR DESCRIPTION
This fixes the regression caused by #685 which does not include `.eslintrc.js` as a lint target.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/686)
<!-- Reviewable:end -->
