### PR TITLE
fix(ExIterable): specialized map should not take over index from filter

### DIFF
--- a/src/client/script/lib/ExIterable.ts
+++ b/src/client/script/lib/ExIterable.ts
@@ -226,12 +226,14 @@ class FilterMapIterator<S, T> implements Iterator<T> {
     private _filter: FilterFn<S>;
     private _selector: MapFn<S, T>;
     private _index: number;
+    private _selectorIndex: number;
 
     constructor(source: Iterator<S>, filter: FilterFn<S>, selector: MapFn<S, T>) {
         this._source = source;
         this._filter = filter;
         this._selector = selector;
         this._index = 0;
+        this._selectorIndex = 0;
     }
 
     next(): IteratorResult<T> {
@@ -240,10 +242,9 @@ class FilterMapIterator<S, T> implements Iterator<T> {
         let next: IteratorResult<S> = source.next();
 
         while (!next.done) {
-            let i = this._index++;
-            const ok: boolean = filter(next.value, i);
+            const ok: boolean = filter(next.value, this._index++);
             if (ok) {
-                const value = this._selector(next.value, i);
+                const value = this._selector(next.value, this._selectorIndex++);
                 return {
                     done: false,
                     value,

--- a/src/client/script/lib/test/test_ExIterable.ts
+++ b/src/client/script/lib/test/test_ExIterable.ts
@@ -312,7 +312,7 @@ describe('ExIterable', function () {
             });
 
             it('expected the following map()\'s index sequence', function () {
-                assert.deepStrictEqual(mapSeqOfFilter, [0, 2, 4]);
+                assert.deepStrictEqual(mapSeqOfFilter, [0, 1, 2]);
             });
         });
     });


### PR DESCRIPTION
The bug fix which is introduced by #692

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/693)
<!-- Reviewable:end -->
