### PR TITLE
refactor(build): generate `.babelrc` just in compile time.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,8 +36,6 @@ const {
 const { getSuffixedCommandName } = require('./tools/platform');
 const { spawnChildProcess, assertReturnCode } = require('./tools/spawn');
 
-const isRelease = process.env.NODE_ENV === 'production';
-
 const NPM_MOD_DIR = path.resolve(__dirname, './node_modules/');
 
 const OBJ_DIR = path.resolve(__dirname, './__obj/');
@@ -146,7 +144,7 @@ gulp.task('build_dist_legacy_lib', ['clean_dist_client'], function () {
 });
 
 gulp.task('build_dist_server', ['clean_dist_server', 'build_obj_server', 'build_obj_lib'], function () {
-    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_SERVER, DIST_SERVER, isRelease);
+    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_SERVER, DIST_SERVER);
 });
 
 gulp.task('build_dist_style', ['stylelint', 'clean_dist_style'], function () {
@@ -243,11 +241,11 @@ gulp.task('test_lib', ['build_test_lib'], function () {
 });
 
 gulp.task('build_test_client', ['clean_test_cache_client', 'build_obj_client'], function () {
-    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_CLIENT, TEST_CACHE_CLIENT, false);
+    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_CLIENT, TEST_CACHE_CLIENT);
 });
 
 gulp.task('build_test_lib', ['clean_test_cache_lib', 'build_obj_lib'], function () {
-    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_LIB, TEST_CACHE_LIB, false);
+    return compileScriptForServer(CWD, NPM_MOD_DIR, OBJ_LIB, TEST_CACHE_LIB);
 });
 
 

--- a/tools/build/babelrc_for_server.js
+++ b/tools/build/babelrc_for_server.js
@@ -1,0 +1,42 @@
+/*eslint quote-props: [2, "always"] */
+
+'use strict';
+
+// This object is encoded to `.babelrc` with using `JSON.stringify()`.
+module.exports = {
+    'presets': [
+    ],
+
+    'plugins': [
+        // For Node.js v6~, we need not some transforms.
+        'transform-es2015-modules-commonjs',
+
+        // es2016 level
+        'babel-plugin-transform-exponentiation-operator',
+        // es2017 level
+        'babel-plugin-syntax-trailing-function-commas',
+        'babel-plugin-transform-async-to-generator',
+
+        // for React
+        'syntax-jsx',
+        'transform-react-jsx',
+    ],
+
+    'env': {
+        'development': {
+            'plugins': [
+                'transform-react-constant-elements',
+                'transform-react-inline-elements',
+            ],
+        },
+
+        'production': {
+            'plugins': [
+                'transform-react-jsx-source',
+            ],
+        },
+    },
+
+    'parserOpts': {},
+    'generatorOpts': {}
+};


### PR DESCRIPTION
## Motivation

1. babel-cli does not support to specify `.babelrc` directly.
2. It's complex that to supply command line args to babel-cli.

## Design

Generate `.babelrc` to the source directory just in compiling time.

By the following document, we should put it to the source directory.

> ### Lookup behavior
> 
> Babel will look for a `.babelrc` in the current directory of the file being transpiled. If one does not exist, it will travel up the directory tree until it finds either a `.babelrc`, or a `package.json` with a `"babel": {}` hash within.
>
> http://babeljs.io/docs/usage/babelrc/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/karen/810)
<!-- Reviewable:end -->
