### PR TITLE
[DO NOT MERGE] feat(GUItoolkit): introduce office-ui-fabric-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express-session": "^1.14.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.15.1",
+    "office-ui-fabric-react": "^0.57.0",
     "option-t": "^3.0.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/src/client/settings/view/ConnectSettingWindow.tsx
+++ b/src/client/settings/view/ConnectSettingWindow.tsx
@@ -25,6 +25,8 @@
 
 import * as React from 'react';
 
+import { Button } from 'office-ui-fabric-react/lib/Button';
+
 import {ConnectionActionCreator} from '../intent/ConnectionSettingIntent';
 import {ConnectionValue} from '../domain/value/ConnectionSettings';
 import {ConnectionSettingViewModel} from '../viewmodel/ConnectionStore';
@@ -194,6 +196,7 @@ export class ConnectSettingWindow extends React.Component<Props, void> {
                                     disabled={isConnecting || !canConnect}>
                                 Connect
                             </button>
+                            <Button>I am a button.</Button>
                         </div>
                     </div>
                 </form>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
         "pretty": true,
         "preserveConstEnums": true,
         "removeComments": false,
+        "skipLibCheck": true, // Avoid the compile error with office-ui-fabric-react
         "sourceMap": true,
         "strictNullChecks": true,
         "suppressImplicitAnyIndexErrors": false,


### PR DESCRIPTION
Introduce [Office-UI-Fabric](http://dev.office.com/fabric) for [react](https://github.com/OfficeDev/office-ui-fabric-react).

Pros
--------------------

- This GUI toolkit is developed with TypeScript,
  thus we don't need to think about d.ts.
- This does not have any layout component. only have GUI parts.
  So I thought we can handle this easily.

Cons
------------

- We need to write some CSS to layout these.
- Microsoft may stop to development this in the future.
  They have the criminal record as known as [WinJS](https://github.com/winjs/winjs) :/